### PR TITLE
Removed fife installer from appveyor and use the zipped file

### DIFF
--- a/build-scripts/2-extract.bat
+++ b/build-scripts/2-extract.bat
@@ -45,7 +45,7 @@ echo Fifengine Dependencies
 
 echo.
 echo Fifengine Python27 Installer
-copy libfife.win32-py2.7.exe "%TARGET_DIR%\libfife.win32-py2.7.exe"
+%ZIP% x libfife.win32-py2.7.zip -o..\extracted\fifengine > nul
 
 dir "%TARGET_DIR%"
 

--- a/build-scripts/3-copy.bat
+++ b/build-scripts/3-copy.bat
@@ -32,6 +32,6 @@ echo Fifengine Dependencies
 move "%EXTRACTED_DIR%\fifengine-includes" "%TARGET_DIR%"
 
 echo Fifengine Python27 Installer 
-move "%EXTRACTED_DIR%\libfife.win32-py2.7.exe" "%TARGET_DIR%"
+move "%EXTRACTED_DIR%\fife" "%TARGET_DIR%"
 
 popd

--- a/download-lists/fifengine.txt
+++ b/download-lists/fifengine.txt
@@ -14,6 +14,6 @@ https://ci.appveyor.com/api/buildjobs/u9kltpny74p2gulf/artifacts/libfife-depende
     out=libfife-dependencies.zip
 
 # Fifengine - Python Installer
-https://ci.appveyor.com/api/buildjobs/u9kltpny74p2gulf/artifacts/libfife-dev-dbb9631.win32-py2.7.exe
+https://ci.appveyor.com/api/buildjobs/u9kltpny74p2gulf/artifacts/libfife-dev-dbb9631-VC14.zip
     dir=downloads
-    out=libfife.win32-py2.7.exe
+    out=libfife.win32-py2.7.zip

--- a/installer/fife-sdk.iss
+++ b/installer/fife-sdk.iss
@@ -101,7 +101,7 @@ Name: "Python\py35";   Description: "[build tools] Python v3.5";                
 Name: swig;            Description: "[build tools] SWIG - interface generator";         Types: full build-tools   
 
 [Files]
-Source: "..\repackage\libfife.win32-py2.7.exe"; DestDir: "{tmp}";                       Flags: recursesubdirs; Components: fifengine
+Source: "..\repackage\fife\*";                  DestDir: "{app}\fifengine";             Flags: recursesubdirs; Components: fifengine
 Source: "..\repackage\fifengine-includes\*";    DestDir: "{app}\fifengine-includes";    Flags: recursesubdirs; Components: dependencies
 Source: "..\repackage\cmake\*";                 DestDir: "{app}\cmake";                 Flags: recursesubdirs; Components: cmake
 Source: "..\repackage\swig\*";                  DestDir: "{app}\swig";                  Flags: recursesubdirs; Components: swig
@@ -113,5 +113,5 @@ Source: "C:\Python35\*";                        DestDir: "{app}\python";        
 ; Define items to run automatically...
 [Run]
 ; install "libfife for python2.7" only when "python27" and "fifengine" are selected
-Filename: "{tmp}\libfife.win32-py2.7.exe";      Components: Python\py27 and fifengine
+; Filename: "{tmp}\libfife.win32-py2.7.exe";      Components: Python\py27 and fifengine
 


### PR DESCRIPTION
Needs more work because the python modul is not in the zip file!

https://ci.appveyor.com/api/buildjobs/u9kltpny74p2gulf/artifacts/libfife-dev-dbb9631-VC14.zip

Dont have the python modul in the zip file and we need python 2.7 installer