### PR TITLE
Remove irrelevant folders from cmake and swig

### DIFF
--- a/build-scripts/2-extract.bat
+++ b/build-scripts/2-extract.bat
@@ -29,6 +29,16 @@ move "%TARGET_DIR%\swig*" "%TARGET_DIR%\swig"
 rd /s /q "%TARGET_DIR%\swig\Doc"
 rd /s /q "%TARGET_DIR%\swig\Examples"
 
+echo.
+echo Strip Python 2.7
+rd /s /q "C:\Python27\Doc"
+rd /s /q "C:\Python27\tcl"
+
+echo.
+echo Strip Python 3.5
+rd /s /q "C:\Python35\Doc"
+rd /s /q "C:\Python35\tcl"
+
 rem echo.
 rem echo Python 
 rem %ZIP% x ActivePython.zip -o%TARGET_DIR% > nul

--- a/build-scripts/2-extract.bat
+++ b/build-scripts/2-extract.bat
@@ -19,11 +19,15 @@ echo.
 echo CMake
 %ZIP% x cmake.zip -o%TARGET_DIR% > nul
 move "%TARGET_DIR%\cmake-*" "%TARGET_DIR%\cmake"
+rd /s /q "%TARGET_DIR%\cmake\doc"
+rd /s /q "%TARGET_DIR%\cmake\man"
 
 echo.
 echo Swig
 %ZIP% x swig.zip -o%TARGET_DIR% > nul
 move "%TARGET_DIR%\swig*" "%TARGET_DIR%\swig"
+rd /s /q "%TARGET_DIR%\swig\Doc"
+rd /s /q "%TARGET_DIR%\swig\Examples"
 
 rem echo.
 rem echo Python 


### PR DESCRIPTION
Cmake and swig are stripped down. But not Python yet.